### PR TITLE
Add 1.3.6 functionality

### DIFF
--- a/src/Component/AbstractComponentFactory.php
+++ b/src/Component/AbstractComponentFactory.php
@@ -80,4 +80,21 @@ abstract class AbstractComponentFactory implements ComponentFactoryInterface
     {
         $element->setAttribute('class', trim($cssClass . ' ' . $element->getAttribute('class')));
     }
+
+    protected function getUsableAttributes(HtmlNode $element, $exclude = [])
+    {
+        $exclude = (array) $exclude;
+        $ignoredAttributes = ['href', 'size', 'size-sm', 'size-lg', 'large', 'no-expander', 'small', 'target'];
+
+        $newAttributes = [];
+        foreach($element->getAttributes() as $attribute => $value)
+        {
+            if(!in_array($attribute, $ignoredAttributes) && !in_array($attribute, $exclude))
+            {
+                $newAttributes[$attribute] = $value;
+            }
+        }
+
+        return $newAttributes;
+    }
 }

--- a/src/Component/ButtonFactory.php
+++ b/src/Component/ButtonFactory.php
@@ -71,10 +71,17 @@ class ButtonFactory extends AbstractComponentFactory
     {
         $attributes = $element->getAttributes();
         if(isset($attributes['href'])) {
-            $href= $attributes['href'];
+            $href = $attributes['href'];
             unset($attributes['href']);
         } else {
             $href = null;
+        }
+
+        if(isset($attributes['target'])) {
+            $target = $attributes['target'];
+            unset($attributes['target']);
+        } else {
+            $target = null;
         }
 
         $table = $this->table($attributes);
@@ -95,6 +102,11 @@ class ButtonFactory extends AbstractComponentFactory
         //wrap in <a /> if element has href
         if($href !== null) {
             $a = $this->node('a', array('href' => (string) $href));
+
+            if($target !== null) {
+                $a->setAttribute('target', (string) $target);
+            }
+
             $lastChild->addChild($a);
             $lastChild = $a;
         }

--- a/src/Component/CalloutFactory.php
+++ b/src/Component/CalloutFactory.php
@@ -47,7 +47,8 @@ class CalloutFactory extends AbstractComponentFactory
      */
     public function parse(HtmlNode $element, Inky $inkyInstance)
     {
-        $table = $this->table(['class' => 'callout']);
+        $table = $this->table($this->getUsableAttributes($element, 'class'));
+        $this->addCssClass('callout', $table);
         $tr = $this->tr();
 
         $th = $this->th($element->getAttributes());

--- a/src/Component/ColumnsFactory.php
+++ b/src/Component/ColumnsFactory.php
@@ -69,6 +69,13 @@ class ColumnsFactory extends AbstractComponentFactory
      */
     public function parse(HtmlNode $element, Inky $inkyInstance)
     {
+        // This is a hack for no-expander because PhpDomParser doesn't seem to support value-less attributes.
+        $outerHtml = $element->outerHtml();
+        if(!$element->getAttribute('no-expander') && stristr($outerHtml, 'no-expander'))
+        {
+            $element->setAttribute('no-expander', 'true');
+        }
+
         $this->setGridColumns($inkyInstance->getGridColumns());
         $th = $this->th($this->getUsableAttributes($element));
         $th->setAttribute('class', $this->prepareCssClass($element));

--- a/src/Component/ColumnsFactory.php
+++ b/src/Component/ColumnsFactory.php
@@ -75,7 +75,7 @@ class ColumnsFactory extends AbstractComponentFactory
         $table = $this->table();
         $tr = $this->tr();
         $childTh = $this->th();
-        $isExpanding = (bool) is_null($element->getAttribute('no-expander'));
+        $isExpanding = (bool) (is_null($element->getAttribute('no-expander')) || $element->getAttribute('no-expander') == 'false');
         $hasRowChildren = $this->hasRowChild($element, $inkyInstance); // must be called before children are moved
         $this->copyChildren($element, $childTh);
         $tr->addChild($childTh);

--- a/src/Component/ColumnsFactory.php
+++ b/src/Component/ColumnsFactory.php
@@ -70,17 +70,17 @@ class ColumnsFactory extends AbstractComponentFactory
     public function parse(HtmlNode $element, Inky $inkyInstance)
     {
         $this->setGridColumns($inkyInstance->getGridColumns());
-        $th = $this->th();
-        $cssClass = $this->prepareCssClass($element);
-        $th->setAttribute('class' ,$cssClass);
+        $th = $this->th($this->getUsableAttributes($element));
+        $th->setAttribute('class', $this->prepareCssClass($element));
         $table = $this->table();
         $tr = $this->tr();
         $childTh = $this->th();
+        $isExpanding = (bool) is_null($element->getAttribute('no-expander'));
         $hasRowChildren = $this->hasRowChild($element, $inkyInstance); // must be called before children are moved
         $this->copyChildren($element, $childTh);
         $tr->addChild($childTh);
         //if element contains as <row />
-        if($hasRowChildren) {
+        if($hasRowChildren && $isExpanding) {
             $expander = $this->th(array('class' => 'expander'));
             $tr->addChild($expander);
         }

--- a/src/Component/ComponentFactoryInterface.php
+++ b/src/Component/ComponentFactoryInterface.php
@@ -16,6 +16,8 @@ namespace Hampe\Inky\Component;
 
 
 use Hampe\Inky\Inky;
+use PHPHtmlParser\Dom\AbstractNode;
+use PHPHtmlParser\Dom\Collection;
 use PHPHtmlParser\Dom\HtmlNode;
 
 interface ComponentFactoryInterface
@@ -30,7 +32,7 @@ interface ComponentFactoryInterface
      * @param HtmlNode $element
      * @param Inky $inkyInstance
      *
-     * @return HtmlNode
+     * @return AbstractNode|Collection
      */
     public function parse(HtmlNode $element, Inky $inkyInstance);
 

--- a/src/Component/MenuItemFactory.php
+++ b/src/Component/MenuItemFactory.php
@@ -52,11 +52,23 @@ class MenuItemFactory extends AbstractComponentFactory
         } else {
             $href = null;
         }
+
+        if(isset($attributes['target'])) {
+            $target = $attributes['target'];
+            unset($attributes['target']);
+        } else {
+            $target = null;
+        }
+
         $th = $this->th($attributes);
         $this->addCssClass('menu-item', $th);
         $a = $this->node('a');
         if($href !== null) {
             $a->setAttribute('href', $href);
+
+            if($target !== null) {
+                $a->setAttribute('target', (string) $target);
+            }
         }
         $this->copyChildren($element, $a);
         $th->addChild($a);

--- a/src/Component/RawFactory.php
+++ b/src/Component/RawFactory.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ *  Row.php
+ *
+ *
+ *  @license    see LICENSE File
+ *  @filename   Row.php
+ *  @package    inky-parse
+ *  @author     Thomas Hampe <github@hampe.co>
+ *  @copyright  2013-2016 Thomas Hampe
+ *  @date       10.01.16
+ */ 
+
+
+namespace Hampe\Inky\Component;
+
+
+use Hampe\Inky\Inky;
+use PHPHtmlParser\Dom\HtmlNode;
+use PHPHtmlParser\Dom\TextNode;
+
+class RawFactory extends AbstractComponentFactory
+{
+
+    const NAME = 'raw';
+
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * <raw><%= test %></raw>
+     * ---------------------------
+     * <%= test %>
+     *
+     * @param HtmlNode $element
+     * @param Inky $inkyInstance
+     *
+     * @return TextNode
+     */
+    public function parse(HtmlNode $element, Inky $inkyInstance)
+    {
+        return new TextNode($element->innerHtml());
+    }
+
+}

--- a/src/Component/SpacerFactory.php
+++ b/src/Component/SpacerFactory.php
@@ -16,6 +16,7 @@ namespace Hampe\Inky\Component;
 
 
 use Hampe\Inky\Inky;
+use PHPHtmlParser\Dom\Collection;
 use PHPHtmlParser\Dom\HtmlNode;
 use PHPHtmlParser\Dom\TextNode;
 
@@ -47,13 +48,34 @@ class SpacerFactory extends AbstractComponentFactory
      */
     public function parse(HtmlNode $element, Inky $inkyInstance)
     {
-        $size = 16;
-        $attributes = $element->getAttributes();
-        if($element->getAttribute('size')) {
-            $size = (int) $element->getAttribute('size');
-            unset($attributes['size']);
+        if($element->getAttribute('size-sm') || $element->getAttribute('size-lg'))
+        {
+            return $this->parseResponsive($element, $inkyInstance);
         }
-        $table = $this->table($attributes);
+
+        return $this->parseNormal($element, $inkyInstance);
+    }
+
+    /**
+     * <spacer size="{size}" />
+     * ---------------------------
+     * <table class="spacer">
+     *    <tbody>
+     *      <tr>
+     *          <td height="{size}px" style="font-size:{size}px;line-height:{size}px;">&#xA0;</td>
+     *      </tr>
+     *    </tbody>
+     * </table>
+     *
+     * @param HtmlNode $element
+     * @param Inky $inkyInstance
+     *
+     * @return HtmlNode
+     */
+    protected function parseNormal(HtmlNode $element, Inky $inkyInstance)
+    {
+        $size = $element->getAttribute('size') ? (int) $element->getAttribute('size') : 16;
+        $table = $this->table($this->getUsableAttributes($element));
         $this->addCssClass('spacer', $table);
         $body = $this->tbody();
         $tr = $this->tr();
@@ -70,5 +92,68 @@ class SpacerFactory extends AbstractComponentFactory
         return $table;
     }
 
+    /**
+     * <spacer size-sm="{size-sm}" size-lg="{size-lg}" />
+     * ---------------------------
+     * <table class="spacer hide-for-large">
+     *    <tbody>
+     *      <tr>
+     *          <td height="{size-sm}px" style="font-size:{size-sm}px;line-height:{size-sm}px;">&#xA0;</td>
+     *      </tr>
+     *    </tbody>
+     * </table>
+     * <table class="spacer show-for-large">
+     *    <tbody>
+     *      <tr>
+     *          <td height="{size-lg}px" style="font-size:{size-lg}px;line-height:{size-lg}px;">&#xA0;</td>
+     *      </tr>
+     *    </tbody>
+     * </table>
+     *
+     * @param HtmlNode $element
+     * @param Inky $inkyInstance
+     *
+     * @return HtmlNode
+     */
+    protected function parseResponsive(HtmlNode $element, Inky $inkyInstance)
+    {
+        $sizes = [];
+        if($element->getAttribute('size-sm'))
+        {
+            $sizes[] = 'size-sm';
+        }
+
+        if($element->getAttribute('size-lg'))
+        {
+            $sizes[] = 'size-lg';
+        }
+
+        $tables = new Collection();
+
+        foreach($sizes as $spacer)
+        {
+            $size = (int) $element->getAttribute($spacer);
+            $table = $this->table($this->getUsableAttributes($element));
+
+            $responsiveClass = $spacer == 'size-sm' ? 'hide-for-large' : 'show-for-large';
+
+            $this->addCssClass('spacer '.$responsiveClass, $table);
+            $body = $this->tbody();
+            $tr = $this->tr();
+            $td = $this->td();
+
+            $td->setAttribute('height', sprintf('%dpx', $size));
+            $td->setAttribute('style', sprintf('font-size:%dpx;line-height:%dpx;', $size, $size));
+            $td->addChild(new TextNode('&#xA0;'));
+
+            $tr->addChild($td);
+            $body->addChild($tr);
+            $table->addChild($body);
+
+            $tables[] = $table;
+        }
+
+        return $tables;
+    }
 
 }

--- a/tests/Component/BlockGridFactoryTest.php
+++ b/tests/Component/BlockGridFactoryTest.php
@@ -20,6 +20,10 @@ class BlockFactoryTest extends AbstractComponentFactoryTest
         'Case 1' => array(
             'from' => '<block-grid up="12">Html</block-grid>',
             'to' => '<table class="block-grid up-12"><tr>Html</tr></table>'
+        ),
+        'Case 2' => array(
+            'from' => '<block-grid up="12" class="show-for-large">Html</block-grid>',
+            'to' => '<table class="block-grid up-12 show-for-large"><tr>Html</tr></table>'
         )
     );
 

--- a/tests/Component/ButtonFactoryTest.php
+++ b/tests/Component/ButtonFactoryTest.php
@@ -67,6 +67,38 @@ class ButtonFactoryTest extends AbstractComponentFactoryTest
                                 </tr>
                               </table>
             ',
+        ),
+        'creates a button with target="_blank"' => array(
+            'from'  => '<button target="_blank" href="http://zurb.com">Button</button>',
+            'to'    => '
+                        <table class="button">
+                            <tr>
+                              <td>
+                                <table>
+                                  <tr>
+                                    <td><a href="http://zurb.com" target="_blank">Button</a></td>
+                                  </tr>
+                                </table>
+                              </td>
+                            </tr>
+                        </table>
+            ',
+        ),
+        'creates a button with classes and target="_blank"' => array(
+            'from'  => '<button class="small alert" target="_blank" href="http://zurb.com">Button</button>',
+            'to'    => '
+                        <table class="button small alert">
+                            <tr>
+                              <td>
+                                <table>
+                                  <tr>
+                                    <td><a href="http://zurb.com" target="_blank">Button</a></td>
+                                  </tr>
+                                </table>
+                              </td>
+                            </tr>
+                        </table>
+            ',
         )
     );
 

--- a/tests/Component/ButtonFactoryTest.php
+++ b/tests/Component/ButtonFactoryTest.php
@@ -33,6 +33,22 @@ class ButtonFactoryTest extends AbstractComponentFactoryTest
                         </table>
                         '
         ),
+        'creates a button with target="_blank" attribute' => array(
+            'from'  => '<button target="_blank" href="http://zurb.com">Button</button>',
+            'to'    => '
+                        <table class="button">
+                            <tr>
+                              <td>
+                                <table>
+                                  <tr>
+                                    <td><a href="http://zurb.com" target="_blank">Button</a></td>
+                                  </tr>
+                                </table>
+                              </td>
+                            </tr>
+                        </table>
+            ',
+        ),
         'creates a button with classes' => array(
             'from'  => '<button class="small alert" href="http://zurb.com">Button</button>',
             'to'    => '
@@ -68,23 +84,7 @@ class ButtonFactoryTest extends AbstractComponentFactoryTest
                               </table>
             ',
         ),
-        'creates a button with target="_blank"' => array(
-            'from'  => '<button target="_blank" href="http://zurb.com">Button</button>',
-            'to'    => '
-                        <table class="button">
-                            <tr>
-                              <td>
-                                <table>
-                                  <tr>
-                                    <td><a href="http://zurb.com" target="_blank">Button</a></td>
-                                  </tr>
-                                </table>
-                              </td>
-                            </tr>
-                        </table>
-            ',
-        ),
-        'creates a button with classes and target="_blank"' => array(
+        'creates a button with classes and target="_blank" attribute' => array(
             'from'  => '<button class="small alert" target="_blank" href="http://zurb.com">Button</button>',
             'to'    => '
                         <table class="button small alert">

--- a/tests/Component/ColumnsFactoryTest.php
+++ b/tests/Component/ColumnsFactoryTest.php
@@ -33,6 +33,14 @@ class ColumnsFactoryTest extends AbstractComponentFactoryTest
             'from' => '<columns small="3" large="5"><row>Html</row></columns>',
             'to' => '<th class="columns small-3 large-5 last first"><table><tr><th><table class="row"><tbody><tr>Html</tr></tbody></table></th><th class="expander"></th></tr></table></th>'
         ),
+        'Case 5 (no expander)' => array(
+            'from' => '<columns small="3" large="5" no-expander><row>Html</row></columns>',
+            'to' => '<th class="columns small-3 large-5 last first"><table><tr><th><table class="row"><tbody><tr>Html</tr></tbody></table></th></tr></table></th>'
+        ),
+        'Case 6 (valign)' => array(
+            'from' => '<columns large="12" valign="top">Html</columns>',
+            'to' => '<th valign="top" class="columns small-12 large-12 last first"><table><tr><th>Html</th></tr></table></th>'
+        ),
     );
 
 }

--- a/tests/Component/ColumnsFactoryTest.php
+++ b/tests/Component/ColumnsFactoryTest.php
@@ -37,9 +37,17 @@ class ColumnsFactoryTest extends AbstractComponentFactoryTest
             'from' => '<columns small="3" large="5" no-expander><row>Html</row></columns>',
             'to' => '<th class="columns small-3 large-5 last first"><table><tr><th><table class="row"><tbody><tr>Html</tr></tbody></table></th></tr></table></th>'
         ),
-        'Case 6 (valign)' => array(
+        'Case 6 (no expander is false)' => array(
+            'from' => '<columns small="3" large="5" no-expander="false"><row>Html</row></columns>',
+            'to' => '<th class="columns small-3 large-5 last first"><table><tr><th><table class="row"><tbody><tr>Html</tr></tbody></table></th><th class="expander"></th></tr></table></th>'
+        ),
+        'Case 7 (valign)' => array(
             'from' => '<columns large="12" valign="top">Html</columns>',
             'to' => '<th valign="top" class="columns small-12 large-12 last first"><table><tr><th>Html</th></tr></table></th>'
+        ),
+        'Case 8 (classes)' => array(
+            'from' => '<columns class="small-offset-8 hide-for-small">Html</columns>',
+            'to' => '<th class="columns small-offset-8 hide-for-small small-12 large-12 last first"><table><tr><th>Html</th></tr></table></th>'
         ),
     );
 

--- a/tests/Component/MenuFactoryTest.php
+++ b/tests/Component/MenuFactoryTest.php
@@ -36,6 +36,26 @@ class MenuFactoryTest extends AbstractComponentFactoryTest {
                       </table>
                         '
         ),
+        'creates a menu with items tags inside, containing target="_blank" attribute' => array(
+            'from'  =>  '
+                        <menu>
+                            <item href="http://zurb.com" target="_blank">Item</item>
+                        </menu>
+                        ',
+            'to'    =>  '
+                      <table class="menu">
+                        <tr>
+                          <td>
+                            <table>
+                              <tr>
+                                <th class="menu-item"><a href="http://zurb.com" target="_blank">Item</a></th>
+                              </tr>
+                            </table>
+                          </td>
+                        </tr>
+                      </table>
+                        '
+        ),
         'creates a menu with classes' => array(
             'from'  =>  '<menu class="vertical"></menu>',
             'to'    =>  '

--- a/tests/Component/MenuItemFactoryTest.php
+++ b/tests/Component/MenuItemFactoryTest.php
@@ -24,6 +24,10 @@ class MenuItemFactoryTest extends AbstractComponentFactoryTest {
             'from' => '<item class="test">Html</item>',
             'to' => '<th class="menu-item test"><a>Html</a></th>'
         ),
+        'Case 3' => array(
+            'from' => '<item class="test" href="http://example.com/123" target="_blank">Html</item>',
+            'to' => '<th class="menu-item test"><a href="http://example.com/123" target="_blank">Html</a></th>'
+        ),
     );
 
 }

--- a/tests/Component/RawFactoryTest.php
+++ b/tests/Component/RawFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ *  MenuFactoryTest.php
+ *
+ *
+ *  @license    see LICENSE File
+ *  @filename   MenuFactoryTest.php
+ *  @package    inky-parse
+ *  @author     Thomas Hampe <github@hampe.co>
+ *  @copyright  2013-2016 Thomas Hampe
+ *  @date       28.02.16
+ */
+
+namespace Component;
+
+class RawFactoryTest extends AbstractComponentFactoryTest {
+
+    protected $testCases = array(
+        'doesn\'t muck with stuff inside raw' => array(
+            'from' => '<raw><%= test %></raw>',
+            'to' => '<%= test %>'
+        ),
+        'can handle multiple raw tags' => array(
+            'from' => '<h1><raw><%= test %></raw></h1><h2><raw>!!!</raw></h2>',
+            'to' => '<h1><%= test %></h1><h2>!!!</h2>'
+        ),
+    );
+
+}

--- a/tests/Component/RawFactoryTest.php
+++ b/tests/Component/RawFactoryTest.php
@@ -16,6 +16,10 @@ namespace Component;
 class RawFactoryTest extends AbstractComponentFactoryTest {
 
     protected $testCases = array(
+        'creates a wrapper that ignores anything inside' => array(
+            'from' => "<raw><<LCG Program\TG LCG Coupon Code Default='246996'>></raw>",
+            'to' => "<<LCG Program\TG LCG Coupon Code Default='246996'>>"
+        ),
         'doesn\'t muck with stuff inside raw' => array(
             'from' => '<raw><%= test %></raw>',
             'to' => '<%= test %>'

--- a/tests/Component/SpacerFactoryTest.php
+++ b/tests/Component/SpacerFactoryTest.php
@@ -30,6 +30,18 @@ class SpacerFactoryTest extends AbstractComponentFactoryTest
                         </table>
                         '
         ),
+        'creates a spacer with a default size or no size defined' => array(
+            'from' =>   '<spacer></spacer>',
+            'to' =>     '
+                        <table class="spacer">
+                            <tbody>
+                              <tr>
+                                <td height="16px" style="font-size:16px;line-height:16px;">&#xA0;</td>
+                              </tr>
+                            </tbody>
+                        </table>
+                        '
+        ),
         'creates a spacer element for small screens with correct size' => array(
             'from' =>   '<spacer size-sm="10"></spacer>',
             'to' =>     '

--- a/tests/Component/SpacerFactoryTest.php
+++ b/tests/Component/SpacerFactoryTest.php
@@ -30,6 +30,49 @@ class SpacerFactoryTest extends AbstractComponentFactoryTest
                         </table>
                         '
         ),
+        'creates a spacer element for small screens with correct size' => array(
+            'from' =>   '<spacer size-sm="10"></spacer>',
+            'to' =>     '
+                        <table class="spacer hide-for-large">
+                            <tbody>
+                              <tr>
+                                <td height="10px" style="font-size:10px;line-height:10px;">&#xA0;</td>
+                              </tr>
+                            </tbody>
+                        </table>
+                        '
+        ),
+        'creates a spacer element for large screens with correct size' => array(
+            'from' =>   '<spacer size-lg="20"></spacer>',
+            'to' =>     '
+                        <table class="spacer show-for-large">
+                            <tbody>
+                              <tr>
+                                <td height="20px" style="font-size:20px;line-height:20px;">&#xA0;</td>
+                              </tr>
+                            </tbody>
+                        </table>
+                        '
+        ),
+        'creates a spacer element for small and large screens with correct sizes' => array(
+            'from' =>   '<spacer size-sm="10" size-lg="20"></spacer>',
+            'to' =>     '
+                        <table class="spacer hide-for-large">
+                            <tbody>
+                              <tr>
+                                <td height="10px" style="font-size:10px;line-height:10px;">&#xA0;</td>
+                              </tr>
+                            </tbody>
+                        </table>
+                        <table class="spacer show-for-large">
+                            <tbody>
+                              <tr>
+                                <td height="20px" style="font-size:20px;line-height:20px;">&#xA0;</td>
+                              </tr>
+                            </tbody>
+                        </table>
+                        '
+        ),
         'copies classes to the final spacer HTML' => array(
             'from' =>   '<spacer size="10" class="bgcolor"></spacer>',
             'to' =>     '


### PR DESCRIPTION
This adds the functionality from 1.3.6 and should close #2 and #4. I didn't make any changes to alter character encoding as this library shouldn't affect that anyway. Ref: https://github.com/thampe/inky/issues/2#issuecomment-231839381  

The biggest change is modifications to `Inky::parse()` to support responsive spacers and the new `<raw>` tag:
- Raw returns a `TextNode`, but it was required to be an `HtmlNode` before
- Responsive spacers are two separate tables, so I added `Collection` as a possible return type

The new tests are pulled directly from zurb/inky, along with a few additional tests.
