### PR TITLE
Containers are not centered,

### DIFF
--- a/src/Component/ContainerFactory.php
+++ b/src/Component/ContainerFactory.php
@@ -46,6 +46,7 @@ class ContainerFactory extends AbstractComponentFactory
     {
         $table = $this->table($element->getAttributes());
         $this->addCssClass('container', $table);
+        $table->setAttribute('align', 'center');
 
         $tbody = $this->tbody();
         $tr = $this->tr();


### PR DESCRIPTION
Fix for containers not centering in MS Outlook. They miss align="center" attribute.
