### PR TITLE
Add possibility to define XML namespace for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $inky->releaseTheKraken('html...');
 use Hampe\Inky\Inky;
 
 $inky = new Inky();
-$inky->addAlias('test', 'callout')
+$inky->addAlias('test', 'callout');
 
 $inky->releaseTheKraken('<test>123</test>'); //equal to "<callout>123</callout>"
 ```
@@ -52,7 +52,7 @@ class TestComponentFactory implements ComponentFactoryInterface
 {
     public function getName()
     {
-        return 'test' // name of the html tag.
+        return 'test'; // name of the html tag.
     }
 
     public function parse(HtmlNode $element, Inky $inkyInstance)
@@ -65,6 +65,37 @@ $inky = new Inky();
 $inky->addComponentFactory(new TestComponentFactory());
 $inky->releaseTheKraken('<test></test>');
 ```
+
+### XML Namespace
+
+If you want to prefix all your inky tags with an XML namespace
+you can set this prefix either in constructor or via setter:
+
+```php
+use Hampe\Inky\Inky;
+
+// Constructor way
+$inky = new Inky(12, [], 'inky');
+
+// Setter way
+$inky2 = new Inky();
+$inky2->setXmlNamespace('inky');
+```
+If you declare your namespace, create a XSD and make
+it know to your IDE you can benefit from autocompletion and 
+validation features of your IDE. Your inky templates might look as
+follows:
+
+```xml
+<inky:container>
+    <inky:row class="my-row">
+        <inky:columns large="6" small="4">
+            ...
+        </inky:columns>
+    </inky:row>
+</inky:container>
+``` 
+
 
 ## License
 See the [LICENSE](LICENSE) file for license info (it's the MIT license).

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,4 +5,9 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Inky.php
+++ b/src/Inky.php
@@ -7,8 +7,9 @@
  *  @filename   Inky.php
  *  @package    inky-parse
  *  @author     Thomas Hampe <github@hampe.co>
- *  @copyright  2013-2016 Thomas Hampe
- *  @date       10.01.16
+ *  @author     Felix Althaus <felix.althaus@undkonsorten.com>
+ *  @copyright  2013-2017 Thomas Hampe
+ *  @date       10.10.17
  */ 
 
 
@@ -44,13 +45,19 @@ class Inky
     protected $componentFactory = array();
 
     /**
+     * @var string
+     */
+    protected $xmlNamespace;
+
+    /**
      * @var int
      */
     protected $gridColumns;
 
-    public function __construct($gridColumns = 12, $componentFactories = array())
+    public function __construct($gridColumns = 12, $componentFactories = array(), $xmlNamespace = null)
     {
         $this->setGridColumns($gridColumns);
+        $this->setXmlNamespace($xmlNamespace);
         $this->addComponentFactory(new RowFactory());
         $this->addComponentFactory(new ContainerFactory());
         $this->addComponentFactory(new ButtonFactory());
@@ -218,7 +225,7 @@ class Inky
     {
         $parseInComplete = false;
         foreach($this->getAllComponentFactories() as $tag => $factory) {
-            $elements = $dom->getElementsByTag($tag);
+            $elements = $dom->getElementsByTag($this->getXmlNamespacePrefix() . $tag);
             foreach($elements as $element) {
                 /** @var AbstractNode|Collection $element */
                 $newElement = $factory->parse($element, $this);
@@ -263,6 +270,34 @@ class Inky
             }
         }
         return $parseInComplete;
+    }
+
+    /**
+     * @param string $xmlNamespace The XML namespace for all inky tags, without colon (:)
+     *   Set to null or empty string to skip XML namespace
+     * @return $this Inky object for method chaining
+     */
+    public function setXmlNamespace($xmlNamespace)
+    {
+        $xmlNamespace = trim($xmlNamespace);
+        $this->xmlNamespace = $xmlNamespace ?: null;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getXmlNamespace()
+    {
+        return $this->xmlNamespace;
+    }
+
+    /**
+     * @return string The XML namespace prefix including colon (:), empty string if no namespace is set
+     */
+    protected function getXmlNamespacePrefix()
+    {
+        return $this->xmlNamespace ? $this->xmlNamespace . ':' : '';
     }
 
 }

--- a/tests/InkyTest.php
+++ b/tests/InkyTest.php
@@ -7,8 +7,9 @@
  *  @filename   Test.php
  *  @package    inky-parse
  *  @author     Thomas Hampe <github@hampe.co>
- *  @copyright  2013-2016 Thomas Hampe
- *  @date       13.03.16
+ *  @author     Felix Althaus <felix.althaus@undkonsorten.com>
+ *  @copyright  2013-2017 Thomas Hampe
+ *  @date       10.10.17
  */
 
 use PHPHtmlParser\Dom;
@@ -40,6 +41,37 @@ class InkyTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(null, $inky->getComponentFactory('test'));
         $this->assertEquals('<test>Test</test>', $inky->releaseTheKraken('<test>Test</test>'));
 
+    }
+
+    public function testXmlNamespace()
+    {
+        $inky = new \Hampe\Inky\Inky(12, [], 'inky');
+        $this->assertEquals('<table class="callout"><tr><th class="callout-inner">Test</th><th class="expander"></th></tr></table>',
+            $inky->releaseTheKraken('<inky:callout>Test</inky:callout>'));
+        $this->assertNotEquals('<table class="callout"><tr><th class="callout-inner">Test</th><th class="expander"></th></tr></table>',
+            '<callout>Test</callout>');
+        $inky->addAlias('test', 'callout');
+        $this->assertEquals('<table class="callout"><tr><th class="callout-inner">Test</th><th class="expander"></th></tr></table>',
+            $inky->releaseTheKraken('<inky:test>Test</inky:test>'));
+        $this->assertEquals('<inky:unknown>Test</inky:unknown>', $inky->releaseTheKraken('<inky:unknown>Test</inky:unknown>'));
+    }
+
+    public function testXmlNamespaceViaSetter()
+    {
+        $inky = new \Hampe\Inky\Inky();
+        $inky->setXmlNamespace('inky');
+        $this->assertEquals('<table class="callout"><tr><th class="callout-inner">Test</th><th class="expander"></th></tr></table>',
+            $inky->releaseTheKraken('<inky:callout>Test</inky:callout>'));
+        $inky->setXmlNamespace(null);
+        $this->assertNotEquals('<table class="callout"><tr><th class="callout-inner">Test</th><th class="expander"></th></tr></table>',
+            $inky->releaseTheKraken('<inky:callout>Test</inky:callout>'));
+    }
+
+    public function testXmlNamespaceGetterAndSetter()
+    {
+        $inky = new Hampe\Inky\Inky();
+        $inky->setXmlNamespace('testns');
+        $this->assertEquals('testns', $inky->getXmlNamespace());
     }
 
     public function testStyles()


### PR DESCRIPTION
You can either define a namespace in constructor or via setter. You can
then prefix tags like `<inky:columns>`. This way you can benefit from
autocompletion and XSD validation.
Fixes #11.